### PR TITLE
feat(ui): persistent sidebar navigation and visual refinements

### DIFF
--- a/easy_dialog.py
+++ b/easy_dialog.py
@@ -38,6 +38,7 @@ from qgis.PyQt.QtWidgets import (
 
 from .view.auth import setup_auth_page
 from .view.download_dem import setup_download_dem_page
+from .view.sidebar import Sidebar
 from .view.styles import STYLE_DIALOG, STYLE_BTN_HELP
 
 
@@ -93,7 +94,7 @@ class EasyDemDialog(QDialog):
             | Qt.WindowType.WindowCloseButtonHint
         )
         self.setWindowModality(Qt.WindowModality.NonModal)
-        self.setFixedSize(800, 400)
+        self.setFixedSize(800, 404)
         self.setStyleSheet(STYLE_DIALOG)
 
         root = QVBoxLayout(self)
@@ -102,24 +103,37 @@ class EasyDemDialog(QDialog):
 
         root.addWidget(self._build_header())
 
-        # Central stack hosts each workflow page inside the fixed-size dialog.
+        # Body row: permanent sidebar + page stack.
+        body = QWidget()
+        body.setStyleSheet("background-color: #f5f5f5;")
+        body_lay = QHBoxLayout(body)
+        body_lay.setContentsMargins(0, 0, 0, 0)
+        body_lay.setSpacing(8)
+
+        self.sidebar = Sidebar()
+        self.sidebar.auth_requested.connect(self._nav_to_auth)
+        self.sidebar.download_requested.connect(self._nav_to_download)
+        body_lay.addWidget(self.sidebar)
+
         self.stack = QStackedWidget()
         self.stack.setFrameShape(QFrame.Shape.NoFrame)
         self.stack.setLineWidth(0)
         self.stack.setStyleSheet("background-color: #f5f5f5;")
-        root.addWidget(self.stack, 1)
+        body_lay.addWidget(self.stack, 1)
 
         self.auth_page = QWidget()
         self.aoi_page = QWidget()
 
-        # Delegate page construction to isolated view modules.
         setup_auth_page(self, self.auth_page)
         setup_download_dem_page(self, self.aoi_page)
 
         self.stack.addWidget(self.auth_page)
         self.stack.addWidget(self.aoi_page)
+        self.stack.currentChanged.connect(self._sync_page_state)
         self.stack.setCurrentWidget(self.auth_page)
+        self._sync_page_state(self.stack.currentIndex())
 
+        root.addWidget(body, 1)
         root.addWidget(self._build_footer())
 
     # -----------------------------------------------------------------------
@@ -195,7 +209,7 @@ class EasyDemDialog(QDialog):
         plain-text label.
         """
         footer = QWidget()
-        footer.setFixedHeight(52)
+        footer.setFixedHeight(56)
         footer.setStyleSheet(
             "background-color: #ffffff;"
             "QLabel { border: none; background: transparent; }"
@@ -241,7 +255,7 @@ class EasyDemDialog(QDialog):
             'text-decoration:none;font-weight:bold;">FARM Analytica</a>. '
             "Get in touch for exclusive and personalized commercial solutions."
         )
-        farm_text.setStyleSheet("color: #616161; font-size: 8px;")
+        farm_text.setStyleSheet("color: #616161; font-size: 10px;")
         farm_text.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
@@ -255,13 +269,33 @@ class EasyDemDialog(QDialog):
 
     def show_aoi_page(self):
         """Switch the stacked widget to the AOI selection page."""
-        self._header_title.setText("Inputs & Parameters")
         self.stack.setCurrentWidget(self.aoi_page)
 
     def show_auth_page(self):
         """Switch the stacked widget to the authentication page."""
-        self._header_title.setText("GEE Configuration")
         self.stack.setCurrentWidget(self.auth_page)
+
+    def _nav_to_auth(self):
+        """Sidebar auth button — always navigates to the auth page."""
+        self.show_auth_page()
+
+    def _nav_to_download(self):
+        """Sidebar download button follows the existing dataset-loading path."""
+        if hasattr(self, "btn_go_to_aoi"):
+            self.btn_go_to_aoi.click()
+            return
+        self.show_aoi_page()
+
+    def _sync_page_state(self, index):
+        """Keep header and sidebar state aligned with the current stack page."""
+        if self.stack.widget(index) is self.auth_page:
+            self._header_title.setText("GEE Configuration")
+            self.sidebar.set_active_page("auth")
+            return
+
+        if self.stack.widget(index) is self.aoi_page:
+            self._header_title.setText("Inputs & Parameters")
+            self.sidebar.set_active_page("download")
 
     def pop_message(self, message, kind):
         """

--- a/view/auth.py
+++ b/view/auth.py
@@ -2,9 +2,9 @@
 """
 Authentication page for the EasyDEM dialog.
 
-Builds the first workflow page: Google Earth Engine project configuration,
-authentication controls, and a shortcut to browse datasets without
-authenticating.  Signal connections are wired externally by ``easy.py``.
+Builds the first workflow page: Google Earth Engine project configuration
+and authentication controls. Signal connections are wired externally by
+``easy.py``.
 """
 
 import os
@@ -35,14 +35,11 @@ def setup_auth_page(dialog, page):
 
     The layout is a two-column row centred vertically on the page:
 
-    - **Left column** (200 px fixed): plugin icon + caption, title label,
+    - **Left column** (220 px fixed): plugin icon + caption, title label,
       plain-text description, and an info box explaining GEE prerequisites.
     - **Right card** (260 px fixed, white rounded card): a ``project_id_input``
       field for the Google Cloud project ID, a ``btn_authenticate`` primary
       action button, and a ``btn_reset_auth`` discrete reset link.
-    - **Below the row**: a ``btn_go_to_aoi`` shortcut that skips authentication
-      and navigates directly to the AOI page.
-
     All interactive widgets are exposed on ``dialog`` so ``easy.py`` can wire
     signal connections without importing this module's internals.
     """
@@ -54,16 +51,16 @@ def setup_auth_page(dialog, page):
     outer.addStretch(2)
 
     row = QHBoxLayout()
-    row.setContentsMargins(24, 0, 24, 0)
-    row.setSpacing(20)
+    row.setContentsMargins(28, 0, 28, 0)
+    row.setSpacing(34)
 
     # ── Left column ───────────────────────────────────────────────────────
     left = QWidget()
-    left.setFixedWidth(200)
+    left.setFixedWidth(230)
     left.setStyleSheet("background: transparent;")
     left_lay = QVBoxLayout(left)
     left_lay.setContentsMargins(0, 0, 0, 0)
-    left_lay.setSpacing(10)
+    left_lay.setSpacing(8)
 
     # Plugin icon + caption — cropped to remove top whitespace in the PNG.
     logo_col = QVBoxLayout()
@@ -100,7 +97,7 @@ def setup_auth_page(dialog, page):
 
     # Page title.
     title_lbl = QLabel("GEE Authentication")
-    title_lbl.setStyleSheet("color: #1a1a1a; font-size: 16px; font-weight: bold;")
+    title_lbl.setStyleSheet("color: #1a1a1a; font-size: 18px; font-weight: bold;")
     left_lay.addWidget(title_lbl)
 
     # Short explanation of why authentication is required.
@@ -110,7 +107,7 @@ def setup_auth_page(dialog, page):
     )
     desc_lbl.setWordWrap(True)
     desc_lbl.setTextFormat(Qt.TextFormat.RichText)
-    desc_lbl.setStyleSheet("color: #616161; font-size: 11px;")
+    desc_lbl.setStyleSheet("color: #616161; font-size: 13px;")
     left_lay.addWidget(desc_lbl)
 
     # Info box — green left border highlights the prerequisite note.
@@ -138,16 +135,18 @@ def setup_auth_page(dialog, page):
         "with the API enabled."
     )
     info_text.setWordWrap(True)
-    info_text.setStyleSheet("color: #1b5e20; font-size: 10px;")
+    info_text.setStyleSheet("color: #1b5e20; font-size: 12px;")
     info_lay.addWidget(info_text, 1)
 
     left_lay.addWidget(info_frame)
     left_lay.addStretch()
+    row.addStretch(1)
     row.addWidget(left)
 
     # ── Right card ────────────────────────────────────────────────────────
     card = QFrame()
-    card.setFixedWidth(260)
+    card.setFixedWidth(258)
+    card.setFixedHeight(218)
     card.setStyleSheet("""
         QFrame {
             background-color: #ffffff;
@@ -157,21 +156,22 @@ def setup_auth_page(dialog, page):
         QLabel { background: transparent; border: none; }
     """)
     card_lay = QVBoxLayout(card)
-    card_lay.setContentsMargins(20, 20, 20, 20)
+    card_lay.setContentsMargins(20, 18, 20, 14)
     card_lay.setSpacing(7)
 
     # Field label.
     pid_lbl = QLabel("PROJECT ID (GOOGLE CLOUD)")
     pid_lbl.setStyleSheet(
-        "color: #9e9e9e; font-size: 10px; letter-spacing: 1px; font-weight: bold;"
+        "color: #9e9e9e; font-size: 11px; letter-spacing: 1px; font-weight: bold;"
     )
     card_lay.addWidget(pid_lbl)
+    card_lay.addSpacing(18)
 
     # Project ID input — underline style with password-toggle via QGIS widget.
     dialog.project_id_input = QgsPasswordLineEdit()
     dialog.project_id_input.setEchoMode(QLineEdit.EchoMode.Normal)
     dialog.project_id_input.setPlaceholderText("e.g. my-geospatial-project-42")
-    dialog.project_id_input.setFixedHeight(30)
+    dialog.project_id_input.setFixedHeight(28)
     dialog.project_id_input.setStyleSheet("""
         QLineEdit {
             background-color: transparent;
@@ -180,7 +180,7 @@ def setup_auth_page(dialog, page):
             border-bottom: 1.5px solid #d0d0d0;
             border-radius: 0;
             padding: 2px 0 6px 0;
-            font-size: 13px;
+            font-size: 14px;
         }
         QLineEdit:focus {
             border-bottom: 2px solid #1b6b39;
@@ -211,19 +211,16 @@ def setup_auth_page(dialog, page):
         QPushButton:hover { color: #c62828; }
     """)
     card_lay.addWidget(dialog.btn_reset_auth, 0, Qt.AlignmentFlag.AlignHCenter)
+    card_lay.addStretch(1)
 
     row.addWidget(card)
+    row.addStretch(1)
     outer.addLayout(row)
 
-    # Shortcut to AOI page without requiring authentication first.
-    browse_row = QHBoxLayout()
-    browse_row.setContentsMargins(0, 10, 0, 0)
-
-    dialog.btn_go_to_aoi = QPushButton("Browse datasets without authenticating →")
+    # Hidden navigation hook used by the sidebar and controller to load
+    # datasets before showing the AOI page.
+    dialog.btn_go_to_aoi = QPushButton(page)
+    dialog.btn_go_to_aoi.hide()
     dialog.btn_go_to_aoi.clicked.connect(dialog.show_aoi_page)
-    browse_row.addStretch()
-    browse_row.addWidget(dialog.btn_go_to_aoi)
-    browse_row.addStretch()
-    outer.addLayout(browse_row)
 
     outer.addStretch(3)

--- a/view/download_dem.py
+++ b/view/download_dem.py
@@ -147,7 +147,15 @@ def setup_download_dem_page(dialog, page):
     dialog.layer_combo.setFixedHeight(28)
     scroll_lay.addWidget(dialog.layer_combo)
 
-    scroll_lay.addSpacing(2)
+    scroll_lay.addSpacing(4)
+
+    # Add Google Hybrid basemap shortcut — placed right under the AOI selector.
+    dialog.btn_hybrid_layer = QPushButton("Add Google Hybrid Layer")
+    dialog.btn_hybrid_layer.setFixedHeight(28)
+    dialog.btn_hybrid_layer.setStyleSheet(STYLE_BTN_SECONDARY)
+    scroll_lay.addWidget(dialog.btn_hybrid_layer)
+
+    scroll_lay.addSpacing(6)
 
     # DEM dataset selector.
     dem_lbl = QLabel("DEM DATASET")
@@ -220,6 +228,8 @@ def setup_download_dem_page(dialog, page):
     dialog.buffer_slider = QSlider(Qt.Orientation.Horizontal)
     dialog.buffer_slider.setMinimum(-300)
     dialog.buffer_slider.setMaximum(300)
+    dialog.buffer_slider.setSingleStep(1)
+    dialog.buffer_slider.setPageStep(10)
     dialog.buffer_slider.setValue(0)
     dialog.buffer_slider.setTickInterval(100)
     dialog.buffer_slider.setTickPosition(QSlider.TickPosition.NoTicks)
@@ -236,11 +246,17 @@ def setup_download_dem_page(dialog, page):
     dialog.buffer_value_lbl.setStyleSheet("color: #616161; font-size: 10px;")
     scroll_lay.addWidget(dialog.buffer_value_lbl)
 
-    dialog.buffer_slider.valueChanged.connect(
-        lambda v: dialog.buffer_value_lbl.setText(
-            f"Buffer: {v:+d} m" if v != 0 else "Buffer: 0 m"
+    def _set_buffer_value(value):
+        value = 0 if -3 <= value <= 3 else value
+        if dialog.buffer_slider.value() != value:
+            dialog.buffer_slider.blockSignals(True)
+            dialog.buffer_slider.setValue(value)
+            dialog.buffer_slider.blockSignals(False)
+        dialog.buffer_value_lbl.setText(
+            f"Buffer: {value:+d} m" if value != 0 else "Buffer: 0 m"
         )
-    )
+
+    dialog.buffer_slider.valueChanged.connect(_set_buffer_value)
 
     scroll_lay.addStretch()
     scroll_area.setWidget(scroll_content)
@@ -276,29 +292,19 @@ def setup_download_dem_page(dialog, page):
 
     panel_lay.addSpacing(6)
 
-    # Action buttons row.
+    # Action buttons row — download centred, sidebar handles back navigation.
     action_row = QHBoxLayout()
     action_row.setContentsMargins(0, 0, 0, 0)
     action_row.setSpacing(8)
 
-    dialog.btn_back_auth = QPushButton("Authentication Screen")
-    dialog.btn_back_auth.setFixedSize(140, 28)
-    dialog.btn_back_auth.setToolTip("Return to GEE authentication")
-    dialog.btn_back_auth.setStyleSheet(STYLE_BTN_SECONDARY)
-    dialog.btn_back_auth.clicked.connect(dialog.show_auth_page)
-    action_row.addWidget(dialog.btn_back_auth, 0, Qt.AlignmentFlag.AlignLeft)
-
     action_row.addStretch(1)
 
-    dialog.btn_hybrid_layer = QPushButton("Add Google Hybrid Layer")
-    dialog.btn_hybrid_layer.setFixedHeight(28)
-    dialog.btn_hybrid_layer.setStyleSheet(STYLE_BTN_SECONDARY)
-    action_row.addWidget(dialog.btn_hybrid_layer, 0, Qt.AlignmentFlag.AlignRight)
-
     dialog.btn_download_dem = QPushButton("Download DEM")
-    dialog.btn_download_dem.setFixedSize(140, 28)
+    dialog.btn_download_dem.setFixedSize(160, 32)
     dialog.btn_download_dem.setStyleSheet(STYLE_BTN_PRIMARY)
-    action_row.addWidget(dialog.btn_download_dem, 0, Qt.AlignmentFlag.AlignRight)
+    action_row.addWidget(dialog.btn_download_dem)
+
+    action_row.addStretch(1)
 
     panel_lay.addLayout(action_row)
 

--- a/view/sidebar.py
+++ b/view/sidebar.py
@@ -1,0 +1,367 @@
+# -*- coding: utf-8 -*-
+"""
+Permanent navigation sidebar for the EasyDEM dialog.
+
+The sidebar owns only presentation and navigation signals. Page switching stays
+in ``easy_dialog.py`` so the dialog can keep header and active state in sync.
+"""
+
+import os
+
+from qgis.PyQt.QtCore import QEasingCurve, QRectF, Qt, QSize, QVariantAnimation, pyqtSignal
+from qgis.PyQt.QtGui import QColor, QFont, QIcon, QPainter, QPainterPath, QPen, QPixmap
+from qgis.PyQt.QtWidgets import (
+    QButtonGroup,
+    QFrame,
+    QHBoxLayout,
+    QLabel,
+    QPushButton,
+    QSizePolicy,
+    QVBoxLayout,
+    QWidget,
+)
+
+
+# Visual tokens kept local because this component is self-contained.
+SIDEBAR_COLLAPSED_WIDTH = 64
+SIDEBAR_EXPANDED_WIDTH = 184
+SIDEBAR_GREEN = "#1F6B3A"
+SIDEBAR_GREEN_DARK = "#195A31"
+SIDEBAR_ACTIVE_BG = "#F2FAF5"
+SIDEBAR_ACTIVE_TEXT = "#17572F"
+SIDEBAR_INDICATOR = "#9FE0B4"
+SIDEBAR_TEXT = "rgba(255, 255, 255, 218)"
+SIDEBAR_MUTED = "rgba(255, 255, 255, 170)"
+SIDEBAR_KEY = "#F4C542"
+
+
+class SidebarNavButton(QPushButton):
+    """Navigation button with a compact rounded active indicator."""
+
+    def __init__(self, text="", parent=None):
+        super().__init__(text, parent)
+        self._indicator_color = QColor(SIDEBAR_INDICATOR)
+
+    def paintEvent(self, event) -> None:
+        super().paintEvent(event)
+        if not self.isChecked():
+            return
+
+        painter = QPainter(self)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        painter.setPen(Qt.PenStyle.NoPen)
+        painter.setBrush(self._indicator_color)
+        height = 28 if self.width() > 80 else 22
+        y = (self.height() - height) / 2
+        painter.drawRoundedRect(QRectF(0, y, 3.5, height), 1.75, 1.75)
+        painter.end()
+
+
+class Sidebar(QFrame):
+    """
+    Permanent left navigation with two checkable page buttons.
+
+    Signals:
+        auth_requested: emitted when the user clicks Auth.
+        download_requested: emitted when the user clicks Download DEM.
+    """
+
+    auth_requested = pyqtSignal()
+    download_requested = pyqtSignal()
+
+    def __init__(self, parent=None):
+        super().__init__(parent)
+        self.setObjectName("Sidebar")
+        self._active_page = "auth"
+        self._expanded = False
+        self.setFixedWidth(SIDEBAR_COLLAPSED_WIDTH)
+        self.setAttribute(Qt.WidgetAttribute.WA_StyledBackground, True)
+
+        self._width_animation = QVariantAnimation(self)
+        self._width_animation.setDuration(160)
+        easing = getattr(getattr(QEasingCurve, "Type", QEasingCurve), "OutCubic")
+        self._width_animation.setEasingCurve(easing)
+        self._width_animation.valueChanged.connect(self._set_animated_width)
+
+        self._build()
+        self._apply_expanded_state(False)
+        self.set_active_page("auth")
+
+    def _build(self) -> None:
+        self._layout = QVBoxLayout(self)
+        lay = self._layout
+        lay.setContentsMargins(10, 18, 10, 18)
+        lay.setSpacing(8)
+
+        self.brand_block = QWidget()
+        self.brand_block.setStyleSheet("background: transparent;")
+        brand_block_lay = QVBoxLayout(self.brand_block)
+        brand_block_lay.setContentsMargins(0, 0, 0, 0)
+        brand_block_lay.setSpacing(0)
+
+        self.brand_panel = self._build_brand_panel()
+        brand_block_lay.addWidget(self.brand_panel, 0, Qt.AlignmentFlag.AlignHCenter)
+        brand_block_lay.addSpacing(8)
+        self.brand_divider = QFrame()
+        self.brand_divider.setObjectName("sidebarBrandDivider")
+        self.brand_divider.setFixedHeight(1)
+        self.brand_divider.setStyleSheet("""
+            QFrame#sidebarBrandDivider {
+                background-color: rgba(255, 255, 255, 38);
+                border: none;
+            }
+        """)
+        brand_block_lay.addWidget(self.brand_divider, 0, Qt.AlignmentFlag.AlignHCenter)
+        brand_block_lay.addSpacing(10)
+        lay.addWidget(self.brand_block)
+
+        self.btn_auth = self._make_button("Auth", "auth")
+        self.btn_auth.clicked.connect(self.auth_requested.emit)
+        lay.addWidget(self.btn_auth)
+
+        self.btn_download = self._make_button("Download DEM", "download")
+        self.btn_download.clicked.connect(self.download_requested.emit)
+        lay.addWidget(self.btn_download)
+
+        self._group = QButtonGroup(self)
+        self._group.setExclusive(True)
+        self._group.addButton(self.btn_auth)
+        self._group.addButton(self.btn_download)
+
+        lay.addStretch()
+
+    def _build_brand_panel(self) -> QWidget:
+        panel = QWidget()
+        panel.setObjectName("sidebarBrand")
+        panel.setFixedHeight(42)
+        panel.setStyleSheet("background: transparent;")
+
+        brand_lay = QHBoxLayout(panel)
+        brand_lay.setContentsMargins(0, 0, 0, 0)
+        brand_lay.setSpacing(8)
+
+        self.brand_icon = QLabel()
+        self.brand_icon.setObjectName("sidebarBrandIcon")
+        self.brand_icon.setFixedSize(32, 32)
+        self.brand_icon.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self.brand_icon.setStyleSheet("""
+            QLabel#sidebarBrandIcon {
+                background-color: rgba(255, 255, 255, 24);
+                border: 1px solid rgba(255, 255, 255, 42);
+                border-radius: 16px;
+            }
+        """)
+        pix = self._load_brand_pixmap()
+        if pix is not None:
+            self.brand_icon.setPixmap(pix)
+        else:
+            self.brand_icon.setText("E")
+            self.brand_icon.setStyleSheet("""
+                QLabel#sidebarBrandIcon {
+                    background-color: rgba(255, 255, 255, 24);
+                    border: 1px solid rgba(255, 255, 255, 42);
+                    border-radius: 16px;
+                    color: #ffffff;
+                    font-size: 14px;
+                    font-weight: bold;
+                }
+            """)
+        brand_lay.addWidget(self.brand_icon)
+
+        self.brand_text = QLabel("EasyDEM")
+        self.brand_text.setObjectName("sidebarBrandText")
+        self.brand_text.setStyleSheet("""
+            QLabel#sidebarBrandText {
+                background: transparent;
+                color: #ffffff;
+                font-size: 13px;
+                font-weight: bold;
+                letter-spacing: 0.4px;
+            }
+        """)
+        brand_lay.addWidget(self.brand_text)
+        brand_lay.addStretch()
+        return panel
+
+    def _make_button(self, text: str, icon_kind: str) -> QPushButton:
+        btn = SidebarNavButton(text)
+        btn.setObjectName("sidebarNavButton")
+        btn.setProperty("navText", text)
+        btn.setCheckable(True)
+        btn.setCursor(Qt.CursorShape.PointingHandCursor)
+        btn.setFixedHeight(42)
+        btn.setIcon(self._make_icon(icon_kind))
+        btn.setIconSize(QSize(20, 20))
+        btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        btn.setToolTip(text)
+        return btn
+
+    def set_active_page(self, page: str) -> None:
+        """Highlight the button matching ``page`` (``'auth'`` or ``'download'``)."""
+        self._active_page = page
+        self.btn_auth.setChecked(page == "auth")
+        self.btn_download.setChecked(page == "download")
+        self._sync_brand_visibility()
+
+    def enterEvent(self, event) -> None:
+        """Expand the navigation rail while the pointer is over it."""
+        self._apply_expanded_state(True)
+        super().enterEvent(event)
+
+    def leaveEvent(self, event) -> None:
+        """Collapse back to an icon rail after the pointer leaves it."""
+        self._apply_expanded_state(False)
+        super().leaveEvent(event)
+
+    def _apply_expanded_state(self, expanded: bool) -> None:
+        self._expanded = expanded
+        side_margin = 14 if expanded else 11
+        self._layout.setContentsMargins(side_margin, 18, side_margin, 18)
+
+        for btn in (self.btn_auth, self.btn_download):
+            btn.setText(btn.property("navText") if expanded else "")
+            btn.setToolTip("" if expanded else btn.property("navText"))
+            btn.setFixedWidth(156 if expanded else 42)
+
+        self.brand_panel.setFixedWidth(156 if expanded else 32)
+        self.brand_block.setFixedWidth(156 if expanded else 42)
+        self.brand_text.setVisible(expanded)
+        self.brand_divider.setFixedWidth(156 if expanded else 28)
+        self._sync_brand_visibility()
+
+        self.setStyleSheet(self._stylesheet(expanded))
+        self._animate_width(SIDEBAR_EXPANDED_WIDTH if expanded else SIDEBAR_COLLAPSED_WIDTH)
+
+    def _sync_brand_visibility(self) -> None:
+        show_brand = self._active_page == "download"
+        self.brand_block.setVisible(show_brand)
+
+    def _animate_width(self, target_width: int) -> None:
+        if self.width() == target_width:
+            return
+        self._width_animation.stop()
+        self._width_animation.setStartValue(self.width())
+        self._width_animation.setEndValue(target_width)
+        self._width_animation.start()
+
+    def _set_animated_width(self, width) -> None:
+        self.setFixedWidth(int(width))
+
+    def _stylesheet(self, expanded: bool) -> str:
+        button_padding = "0 12px 0 10px" if expanded else "0"
+        button_radius = "8px"
+        button_text_align = "left" if expanded else "center"
+        button_width = "156px" if expanded else "42px"
+        return f"""
+        QFrame#Sidebar {{
+            background-color: qlineargradient(
+                x1:0, y1:0, x2:0, y2:1,
+                stop:0 {SIDEBAR_GREEN},
+                stop:1 {SIDEBAR_GREEN_DARK}
+            );
+            border: none;
+            border-right: 1px solid rgba(20, 76, 41, 180);
+        }}
+        QPushButton#sidebarNavButton {{
+            background-color: transparent;
+            color: {SIDEBAR_TEXT};
+            border: none;
+            border-radius: {button_radius};
+            font-size: 12px;
+            font-weight: bold;
+            text-align: {button_text_align};
+            padding: {button_padding};
+            min-width: {button_width};
+            max-width: {button_width};
+            min-height: 42px;
+            max-height: 42px;
+        }}
+        QPushButton#sidebarNavButton:hover {{
+            background-color: rgba(255, 255, 255, 22);
+            color: #ffffff;
+        }}
+        QPushButton#sidebarNavButton:checked {{
+            background-color: transparent;
+            color: #ffffff;
+        }}
+        QPushButton#sidebarNavButton:disabled {{
+            color: {SIDEBAR_MUTED};
+        }}
+        """
+
+    def _make_icon(self, kind: str) -> QIcon:
+        """Create simple line icons so the sidebar avoids platform emoji styles."""
+        icon = QIcon()
+        if kind == "auth":
+            key_pix = self._draw_key_emoji_icon()
+            icon.addPixmap(key_pix, QIcon.Mode.Normal, QIcon.State.Off)
+            icon.addPixmap(key_pix, QIcon.Mode.Normal, QIcon.State.On)
+            icon.addPixmap(key_pix, QIcon.Mode.Active, QIcon.State.Off)
+            return icon
+
+        icon.addPixmap(self._draw_icon(kind, "#E9F4ED"), QIcon.Mode.Normal, QIcon.State.Off)
+        icon.addPixmap(self._draw_icon(kind, "#FFFFFF"), QIcon.Mode.Normal, QIcon.State.On)
+        icon.addPixmap(self._draw_icon(kind, "#FFFFFF"), QIcon.Mode.Active, QIcon.State.Off)
+        return icon
+
+    def _draw_key_emoji_icon(self) -> QPixmap:
+        pix = QPixmap(20, 20)
+        pix.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(pix)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        font = QFont("Segoe UI Emoji")
+        font.setPixelSize(15)
+        painter.setFont(font)
+        painter.drawText(pix.rect(), Qt.AlignmentFlag.AlignCenter, "\U0001f511")
+        painter.end()
+        return pix
+
+    def _load_brand_pixmap(self):
+        plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        icon_path = os.path.join(plugin_dir, "icon.png")
+        if not os.path.exists(icon_path):
+            return None
+
+        raw = QPixmap(icon_path)
+        crop_top = int(raw.height() * 0.11)
+        cropped = raw.copy(0, crop_top, raw.width(), raw.height() - crop_top)
+        square = cropped.scaled(
+            26,
+            26,
+            Qt.AspectRatioMode.IgnoreAspectRatio,
+            Qt.TransformationMode.SmoothTransformation,
+        )
+        rounded = QPixmap(26, 26)
+        rounded.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(rounded)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        path = QPainterPath()
+        path.addEllipse(0, 0, 26, 26)
+        painter.setClipPath(path)
+        painter.drawPixmap(0, 0, square)
+        painter.end()
+        return rounded
+
+    def _draw_icon(self, kind: str, color: str) -> QPixmap:
+        pix = QPixmap(20, 20)
+        pix.fill(Qt.GlobalColor.transparent)
+
+        painter = QPainter(pix)
+        painter.setRenderHint(QPainter.RenderHint.Antialiasing)
+        pen = QPen(QColor(color), 1.8)
+        pen.setCapStyle(Qt.PenCapStyle.RoundCap)
+        pen.setJoinStyle(Qt.PenJoinStyle.RoundJoin)
+
+        if kind == "auth":
+            painter.setPen(Qt.PenStyle.NoPen)
+        else:
+            painter.setPen(pen)
+            painter.drawLine(10, 3, 10, 12)
+            painter.drawLine(6, 9, 10, 13)
+            painter.drawLine(14, 9, 10, 13)
+            painter.drawLine(5, 16, 15, 16)
+
+        painter.end()
+        return pix

--- a/view/styles.py
+++ b/view/styles.py
@@ -52,7 +52,7 @@ QPushButton {
     color: #ffffff;
     border: none;
     border-radius: 8px;
-    font-size: 12px;
+    font-size: 13px;
     font-weight: bold;
     padding: 0 16px;
 }
@@ -73,7 +73,7 @@ QPushButton {
     color: #1b6b39;
     border: 1px solid #c8d8ce;
     border-radius: 7px;
-    font-size: 10px;
+    font-size: 11px;
     font-weight: bold;
     padding: 0 12px;
 }
@@ -110,16 +110,16 @@ QLabel {
 }
 QLabel#aoiTitle {
     color: #1a1a1a;
-    font-size: 15px;
+    font-size: 17px;
     font-weight: bold;
 }
 QLabel#aoiSubtitle {
     color: #616161;
-    font-size: 10px;
+    font-size: 12px;
 }
 QLabel#aoiFieldLabel {
     color: #9e9e9e;
-    font-size: 9px;
+    font-size: 11px;
     font-weight: bold;
     letter-spacing: 1px;
 }
@@ -130,7 +130,7 @@ QComboBox, QgsMapLayerComboBox {
     border: 1px solid #d0d0d0;
     border-radius: 6px;
     padding: 4px 8px;
-    font-size: 11px;
+    font-size: 13px;
 }
 QComboBox:focus, QgsMapLayerComboBox:focus {
     border: 1.5px solid #1b6b39;
@@ -149,7 +149,7 @@ QTextBrowser#demInfo {
     border: 1px solid #e0e0e0;
     border-radius: 8px;
     padding: 8px;
-    font-size: 11px;
+    font-size: 12px;
 }
 QTextBrowser#demInfo:focus {
     border-color: #1b6b39;


### PR DESCRIPTION
## What was done

Implements the permanent navigation sidebar as requested, along with visual refinements across the plugin interface.

## Changes

### Sidebar (`view/sidebar.py` — new file)
- Permanent sidebar visible on all pages
- Two navigation buttons: **Auth** and **Download DEM**
- Active item highlighted with an animated left-side indicator
- Active state synchronized via `_sync_page_state` in the dialog
- Collapsible rail: collapses to 64 px (icon only) and expands to 184 px on hover

### Navigation (`easy_dialog.py`)
- Sidebar integrated into the main layout
- `_sync_page_state` connected to the stack's `currentChanged` — ensures synchronization regardless of what triggers the page switch
- "Back" button removed from the Download DEM page (redundant with the sidebar)

### Download DEM page (`view/download_dem.py`)
- "Download DEM" button centered in the action area
- "Add Google Hybrid Layer" button moved directly below the AOI layer selector

### Styles (`view/styles.py`, `view/auth.py`)
- Font sizes increased throughout the interface
- Refined color palette
- Improved typographic hierarchy and spacing

## Acceptance criteria met

- [x] Sidebar visible on all pages
- [x] Two navigation buttons: Auth and Download DEM
- [x] Active page highlighted visually
- [x] Active state synchronized regardless of the trigger
- [x] Redundant buttons removed
- [x] Download DEM button centered
- [x] Google Hybrid Layer below the AOI selector
- [x] All font sizes increased