### PR TITLE
refactor(ui): polish auth page layout and footer visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ qgis-EasyDEM/
 │   ├── __init__.py      # View package marker
 │   ├── auth.py          # Authentication page widget construction (setup_auth_page)
 │   ├── download_dem.py  # AOI/DEM page widget construction (setup_download_dem_page)
+│   ├── sidebar.py       # Permanent collapsible navigation sidebar (Sidebar, SidebarNavButton)
 │   └── styles.py        # Shared Qt stylesheet constants (STYLE_DIALOG, STYLE_BTN_PRIMARY, …)
 └── services/
     ├── __init__.py      # Exports service classes
@@ -57,11 +58,13 @@ The QGIS plugin entry point. Handles toolbar/menu registration (`initGui`), tear
 Contains `EasyDemDialog(QDialog)`. Owns the dialog shell only: fixed header, central `QStackedWidget`, and fixed footer. Page widget construction is delegated to `view/auth.py` and `view/download_dem.py`. No knowledge of services or the `ee` SDK — all signal connections are made externally by the controller.
 
 Internal conventions:
-- `_setup_ui()` — builds header, stack, and footer; calls `setup_auth_page` and `setup_download_dem_page`
+- `_setup_ui()` — builds header, body row (sidebar + stack), and footer; calls `setup_auth_page` and `setup_download_dem_page`
 - `_build_header()` — white bar with brand label, dynamic page-title label (`_header_title`), and help button
 - `_build_footer()` — FARM Analytica logo and attribution text
-- `show_auth_page()` / `show_aoi_page()` — switch the active stack page and update `_header_title`
+- `show_auth_page()` / `show_aoi_page()` — switch the active stack page
+- `_sync_page_state(index)` — connected to `stack.currentChanged`; updates `_header_title` and calls `sidebar.set_active_page()` to keep navigation state in sync regardless of what triggers the page switch
 - Two pages managed by a `QStackedWidget`: `auth_page` shown on first open, `aoi_page` shown after authentication (or via the skip shortcut)
+- Permanent `Sidebar` instance lives in the body row; its `auth_requested` and `download_requested` signals are connected to `_nav_to_auth` and `_nav_to_download`
 
 ### `view/` — Page Modules
 
@@ -89,9 +92,17 @@ Builds the AOI and DEM download page (`setup_download_dem_page`). Layout: scroll
 | `QLabel` | `buffer_value_lbl` | Live display of current buffer value |
 | `QLineEdit` | `folder_input` | Download destination path (read-only display) |
 | `QPushButton` | `btn_browse_folder` | Opens folder picker dialog |
-| `QPushButton` | `btn_back_auth` | Returns to the authentication page |
 | `QPushButton` | `btn_hybrid_layer` | Adds a Google Hybrid basemap layer to QGIS |
 | `QPushButton` | `btn_download_dem` | Downloads and loads the selected DEM into QGIS |
+
+#### `view/sidebar.py`
+Defines `Sidebar(QFrame)` and `SidebarNavButton(QPushButton)`. The sidebar is a permanent collapsible navigation rail shown on all pages. It collapses to 64 px (icon only) and expands to 184 px on hover via `QVariantAnimation`.
+
+| Widget / method | Purpose |
+|---|---|
+| `btn_auth` | Navigates to the authentication page; emits `auth_requested` |
+| `btn_download` | Navigates to the AOI/download page; emits `download_requested` |
+| `set_active_page(page)` | Highlights the button matching `'auth'` or `'download'`; called by `_sync_page_state` in the dialog |
 
 #### `view/styles.py`
 Shared Qt stylesheet string constants imported by both page modules and `easy_dialog.py`.
@@ -196,6 +207,7 @@ If you are an AI assistant working on this codebase, read this before making cha
 **Where things live:**
 - New widgets on the auth page → `view/auth.py` (`setup_auth_page`)
 - New widgets on the AOI/download page → `view/download_dem.py` (`setup_download_dem_page`)
+- Sidebar navigation changes (buttons, icons, expand/collapse behaviour) → `view/sidebar.py`
 - New shared stylesheet constants → `view/styles.py`
 - New signal connections → `easy.py` (inside the `if self.first_start` block in `run()`)
 - New DEM handler/orchestration logic → `dem_handler.py`

--- a/easy_dialog.py
+++ b/easy_dialog.py
@@ -130,11 +130,14 @@ class EasyDemDialog(QDialog):
         self.stack.addWidget(self.auth_page)
         self.stack.addWidget(self.aoi_page)
         self.stack.currentChanged.connect(self._sync_page_state)
+
+        self.footer = self._build_footer()
+
         self.stack.setCurrentWidget(self.auth_page)
         self._sync_page_state(self.stack.currentIndex())
 
         root.addWidget(body, 1)
-        root.addWidget(self._build_footer())
+        root.addWidget(self.footer)
 
     # -----------------------------------------------------------------------
     # HEADER
@@ -209,19 +212,19 @@ class EasyDemDialog(QDialog):
         plain-text label.
         """
         footer = QWidget()
-        footer.setFixedHeight(56)
+        footer.setFixedHeight(36)
         footer.setStyleSheet(
             "background-color: #ffffff;"
             "QLabel { border: none; background: transparent; }"
         )
 
         lay = QHBoxLayout(footer)
-        lay.setContentsMargins(28, 6, 28, 6)
+        lay.setContentsMargins(28, 4, 28, 4)
         lay.setSpacing(8)
 
         # FARM Analytica logo — falls back to plain text if SVG is missing.
         farm_icon = QLabel()
-        farm_icon.setFixedHeight(24)
+        farm_icon.setFixedHeight(16)
         farm_icon.setStyleSheet("background: transparent;")
         logo_path = os.path.join(
             os.path.dirname(os.path.abspath(__file__)),
@@ -230,14 +233,14 @@ class EasyDemDialog(QDialog):
         )
         if os.path.exists(logo_path):
             pix = QPixmap(logo_path).scaledToHeight(
-                24, Qt.TransformationMode.SmoothTransformation
+                16, Qt.TransformationMode.SmoothTransformation
             )
             farm_icon.setPixmap(pix)
             farm_icon.setFixedWidth(pix.width())
         else:
             farm_icon.setText("FARM ANALYTICA")
             farm_icon.setStyleSheet(
-                "color: #1b6b39; font-size: 10px; font-weight: bold;"
+                "color: #1b6b39; font-size: 9px; font-weight: bold;"
             )
         farm_icon.setAlignment(
             Qt.AlignmentFlag.AlignVCenter | Qt.AlignmentFlag.AlignLeft
@@ -248,14 +251,14 @@ class EasyDemDialog(QDialog):
         farm_text = QLabel()
         farm_text.setTextFormat(Qt.TextFormat.RichText)
         farm_text.setOpenExternalLinks(True)
-        farm_text.setWordWrap(True)
+        farm_text.setWordWrap(False)
         farm_text.setText(
             "This is a free and open project, supported by "
             '<a href="https://farmanalytica.com.br" style="color:#1b6b39;'
             'text-decoration:none;font-weight:bold;">FARM Analytica</a>. '
             "Get in touch for exclusive and personalized commercial solutions."
         )
-        farm_text.setStyleSheet("color: #616161; font-size: 10px;")
+        farm_text.setStyleSheet("color: #9e9e9e; font-size: 9px;")
         farm_text.setSizePolicy(
             QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Preferred
         )
@@ -291,11 +294,13 @@ class EasyDemDialog(QDialog):
         if self.stack.widget(index) is self.auth_page:
             self._header_title.setText("GEE Configuration")
             self.sidebar.set_active_page("auth")
+            self.footer.setVisible(True)
             return
 
         if self.stack.widget(index) is self.aoi_page:
             self._header_title.setText("Inputs & Parameters")
             self.sidebar.set_active_page("download")
+            self.footer.setVisible(False)
 
     def pop_message(self, message, kind):
         """

--- a/view/auth.py
+++ b/view/auth.py
@@ -62,38 +62,7 @@ def setup_auth_page(dialog, page):
     left_lay.setContentsMargins(0, 0, 0, 0)
     left_lay.setSpacing(8)
 
-    # Plugin icon + caption — cropped to remove top whitespace in the PNG.
-    logo_col = QVBoxLayout()
-    logo_col.setSpacing(4)
-    logo_col.setAlignment(Qt.AlignmentFlag.AlignLeft)
-
-    icon_lbl = QLabel()
-    icon_lbl.setFixedSize(50, 40)
-    plugin_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-    icon_path = os.path.join(plugin_dir, "icon.png")
-    if os.path.exists(icon_path):
-        raw = QPixmap(icon_path)
-        crop_top = int(raw.height() * 0.11)
-        cropped = raw.copy(0, crop_top, raw.width(), raw.height() - crop_top)
-        pix = cropped.scaled(
-            40, 40,
-            Qt.AspectRatioMode.IgnoreAspectRatio,
-            Qt.TransformationMode.SmoothTransformation,
-        )
-        icon_lbl.setPixmap(pix)
-    else:
-        icon_lbl.setText("\U0001f5fa")
-        icon_lbl.setStyleSheet("font-size: 28px;")
-    icon_lbl.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    icon_lbl.setStyleSheet("background: transparent; border: none;")
-    logo_col.addWidget(icon_lbl)
-
-    icon_caption = QLabel("EasyDEM")
-    icon_caption.setFixedWidth(50)
-    icon_caption.setAlignment(Qt.AlignmentFlag.AlignCenter)
-    icon_caption.setStyleSheet("color: #9e9e9e; font-size: 9px; letter-spacing: 0.5px;")
-    logo_col.addWidget(icon_caption)
-    left_lay.addLayout(logo_col)
+    left_lay.addStretch(1)
 
     # Page title.
     title_lbl = QLabel("GEE Authentication")
@@ -139,7 +108,7 @@ def setup_auth_page(dialog, page):
     info_lay.addWidget(info_text, 1)
 
     left_lay.addWidget(info_frame)
-    left_lay.addStretch()
+    left_lay.addStretch(1)
     row.addStretch(1)
     row.addWidget(left)
 

--- a/view/sidebar.py
+++ b/view/sidebar.py
@@ -233,8 +233,7 @@ class Sidebar(QFrame):
         self._animate_width(SIDEBAR_EXPANDED_WIDTH if expanded else SIDEBAR_COLLAPSED_WIDTH)
 
     def _sync_brand_visibility(self) -> None:
-        show_brand = self._active_page == "download"
-        self.brand_block.setVisible(show_brand)
+        self.brand_block.setVisible(True)
 
     def _animate_width(self, target_width: int) -> None:
         if self.width() == target_width:


### PR DESCRIPTION
- Removed the EasyDEM logo and caption from the Authentication page; brand icon is now shown exclusively in the sidebar.
- Sidebar brand logo is now always visible regardless of the active page.
- Reduced footer height and softened its styling to make it more discreet.
- Footer is now visible only on the Authentication page and hidden on the Download DEM page.
